### PR TITLE
Fix logger and add cache deallocate to goose

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -60,10 +60,11 @@ func NewProvider(dialect Dialect, db *sql.DB, fsys fs.FS, opts ...ProviderOption
 		fsys = noopFS{}
 	}
 	cfg := config{
-		registered:      make(map[int64]*Migration),
-		excludePaths:    make(map[string]bool),
-		excludeVersions: make(map[int64]bool),
-		logger:          &stdLogger{},
+		registered:               make(map[int64]*Migration),
+		excludePaths:             make(map[string]bool),
+		excludeVersions:          make(map[int64]bool),
+		logger:                   &stdLogger{},
+		deallocateStatementCache: func(_ context.Context, _ *sql.Conn) error { return nil },
 	}
 	for _, opt := range opts {
 		if err := opt.apply(&cfg); err != nil {

--- a/provider_run.go
+++ b/provider_run.go
@@ -204,6 +204,13 @@ func (p *Provider) runMigrations(
 				Err:     err,
 			}
 		}
+
+		// after each migration, we deallocate the statement cache so if the migration changed the schema of the database,
+		// which is very likely, the next migration will not fail on statement cache error.
+		if err := p.cfg.deallocateStatementCache(ctx, conn); err != nil {
+			return nil, fmt.Errorf("failed to deallocate statement cache for migration %d: %w", m.Version, err)
+		}
+
 		result.Duration = time.Since(start)
 		results = append(results, result)
 		p.printf("%s", result)


### PR DESCRIPTION
- Adding support for deallocating prepared statement cache after each migration
- Allow setting the goose provider logger